### PR TITLE
Add UID:GID instructions to docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ version: '3'
 services:
   previews:
     image: stevezzau/plex_generate_vid_previews:latest
+    user: 1024:100 # UID:GID to use when creating new files and directories. Remove to run as root.
     environment:
       - PLEX_URL=https://xxxxxx.plex.direct:32400 
       - PLEX_TOKEN=your-plex-token 


### PR DESCRIPTION
The common environment variables `PUID` and `GUID` do not do anything, so the amended docker-compose example uses the native docker engine function to launch the container in the context of the stated UID:GID.

I see that the `docker run` example includes the non-working PUID/GUID environment variables - so now I am not sure if this is functionality that is intended to work and doesn't, or if the example `docker run` has included them by mistake?