### PR TITLE
Add Intel iGPU support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ rich==13.7.1
 python-dotenv==1.0.1
 amdsmi==6.2.1
 pynvml==11.5.3
+psutil==7.0.0


### PR DESCRIPTION
Let me start off by saying this is probably not the complete solution, but it seems to be working fine for me.  I couldn't get it working without running the container as root, but I believe that is because of the ownership of the /dev/dri devices.  I run plex on the same server, and the linuxserver.io plex container does some user permission changes to the igpu device to make it work inside the plex container .

With that said, this seems to work, but welcome comments/testing intel/testing of nvidia/amd (I tried to keep those the same except the if statements for intel).  To note, I have an i5-14500 with a UHD770.  Probably needs more work to support older models, but should really only be related to the driver.

Just need to map in the device in compose file:

```
---
version: '3'
services:
  previews:
    image: <img>:latest
#    user: 1000:1000 # UID:GID to use when creating new files and directories. Remove to run as root.
    devices:
      - "/dev/dri/:/dev/dri/"    # <----- to map the device in
```

Had to tweak the ffmpeg cmd, I welcome comments or changes.  Should resolve  #50 



![Screenshot 2025-04-11 212750](https://github.com/user-attachments/assets/1fc4a1a6-9558-4382-947d-080fdcfda096)

```
previews-1  | 2025/04/12 04:26:58 | ℹ️  - Found INTEL GPU /dev/dri/renderD128
previews-1  | 2025/04/12 04:27:26 | ℹ️  - Generated Video Preview for /movies/movie1.mkv HW=True TIME=18.1seconds SPEED=661x
previews-1  | 2025/04/12 04:27:28 | ℹ️  - Generated Video Preview for /movies/movie2.mkv HW=True TIME=29.6seconds SPEED=461x
previews-1  | 2025/04/12 04:27:31 | ℹ️  - Generated Video Preview for /movies/movie3.avi HW=True TIME=45.7seconds SPEED=140x
previews-1  | 2025/04/12 04:27:56 | ℹ️  - Generated Video Preview for /movies/movie4.mkv HW=True TIME=28.1seconds SPEED=159x
previews-1  | 2025/04/12 04:28:03 | ℹ️  - Generated Video Preview for /movies/movie5.mkv HW=True TIME=81.8seconds SPEED=85.6x
```

