### PR TITLE
Retry FFmpeg without skip_frame

### DIFF
--- a/plex_generate_previews.py
+++ b/plex_generate_previews.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
-import sys
-import re
-import subprocess
-import shutil
-import glob
-import os
-import struct
-import urllib3
 import array
-import time
+import glob
 import http.client
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import time
 import xml.etree.ElementTree
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 from concurrent.futures import ProcessPoolExecutor
 
+import urllib3
 from dotenv import load_dotenv
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 load_dotenv()
 
@@ -601,9 +601,11 @@ if __name__ == '__main__':
         elif gpu == 'INTEL':
             logger.info(f'Found INTEL GPU {gpu_device_path}')
         if not gpu:
-            # Only show warning if no GPU was found
-            logger.warning(f'No GPUs detected. Please set env variable GPU_THREADS to 0, it is currently set to {GPU_THREADS}.')
-            logger.warning('If you think this is an error please log an issue here https://github.com/stevezau/plex_generate_vid_previews/issues')
+            # Exit and require user to explicitly set GPU_THREADS to 0
+            logger.error(f'No GPUs detected but GPU_THREADS is set to {GPU_THREADS}.')
+            logger.error('Please set the GPU_THREADS environment variable to 0 to use CPU-only processing.')
+            logger.error('If you think this is an error please log an issue here https://github.com/stevezau/plex_generate_vid_previews/issues')
+            exit(1)
 
     try:
         # Clean TMP Folder


### PR DESCRIPTION
I had a bunch of files give me outputs saying: 

2025/08/30 14:07:18 | ❌  - [' Terminating thread with return code -22 (Invalid
argument)\r', ' Nothing was written into output file, because at least one of 
its streams received no packets.\r', 'frame=    0 fps=0.0 q=0.0 Lsize=       
0KiB time=N/A bitrate=N/A speed=N/A elapsed=0:00:27.01    \r', 'Conversion 
failed!\r', '']
2025/08/30 14:07:18 | ⚠️  - Problem trying to ffmpeg images for 
myfile.mkv

I noticed it was the "-skip_frame:v nokey" argument that was causing this for said files. I added a retry attempt on failures where it does it without that argument included. It is slower to process but it does work now. I don't really understand much of what ffmpeg is actually doing or why this works, but it solved my problem.