### PR TITLE
Run a quick check to determine if "skip_frame:v nokey" is safe

### DIFF
--- a/plex_generate_previews.py
+++ b/plex_generate_previews.py
@@ -271,6 +271,40 @@ def get_intel_ffmpeg_processes():
     
     return intel_gpu_processes
 
+def heuristic_allows_skip(ffmpeg_path: str, video_file: str) -> bool:
+    """
+    Using the first 10 frames of file to decide if -skip_frame:v nokey is safe.
+    Uses -err_detect explode + -xerror to bail immediately on the first decode error.
+    Returns True if the probe succeeds, else False. Logs a short tail if available.
+    """
+    null_sink = "NUL" if os.name == "nt" else "/dev/null"
+    cmd = [
+        ffmpeg_path,
+        "-hide_banner", "-nostats",
+        "-v", "error",            # only errors
+        "-xerror",                # make errors set non-zero exit
+        "-err_detect", "explode", # fail fast on decode issues
+        "-skip_frame:v", "nokey",
+        "-threads:v", "1",
+        "-i", video_file,
+        "-an", "-sn", "-dn",
+        "-frames:v", "10",         # stop as soon as one frame decodes
+        "-f", "null", null_sink
+    ]
+    proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    ok = (proc.returncode == 0)
+    if not ok:
+        last = (proc.stderr or "").strip().splitlines()[-1:]  # tail(1)
+        if 'logger' in globals():
+            logger.debug(f"skip_frame probe FAILED at 0s: rc={proc.returncode} msg={last}")
+        else:
+            print(f"[probe] fail at 0s: {last}")
+    else:
+        if 'logger' in globals():
+            logger.debug("skip_frame probe OK at 0s")
+    return ok
+
+
 def generate_images(video_file, output_folder, gpu, gpu_device_path):
     media_info = MediaInfo.parse(video_file)
     vf_parameters = "fps=fps={}:round=up,scale=w=320:h=240:force_original_aspect_ratio=decrease".format(
@@ -281,10 +315,19 @@ def generate_images(video_file, output_folder, gpu, gpu_device_path):
         if media_info.video_tracks[0].hdr_format != "None" and media_info.video_tracks[0].hdr_format is not None:
             vf_parameters = "fps=fps={}:round=up,zscale=t=linear:npl=100,format=gbrpf32le,zscale=p=bt709,tonemap=tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p,scale=w=320:h=240:force_original_aspect_ratio=decrease".format(round(1 / PLEX_BIF_FRAME_INTERVAL, 6))
     args = [
-        FFMPEG_PATH, "-loglevel", "info", "-skip_frame:v", "nokey", "-threads:0", "1", "-i",
-        video_file, "-an", "-sn", "-dn", "-q:v", str(THUMBNAIL_QUALITY),
-        "-vf",
-        vf_parameters, '{}/img-%06d.jpg'.format(output_folder)
+        FFMPEG_PATH, "-loglevel", "info",
+        "-threads:v", "1",  # fix: was '-threads:0 1'
+    ]
+
+    use_skip = heuristic_allows_skip(FFMPEG_PATH, video_file)
+    if use_skip:
+        args += ["-skip_frame:v", "nokey"]
+
+    args += [
+        "-i", video_file, "-an", "-sn", "-dn",
+        "-q:v", str(THUMBNAIL_QUALITY),
+        "-vf", vf_parameters,
+        '{}/img-%06d.jpg'.format(output_folder)
     ]
 
     start = time.time()


### PR DESCRIPTION
Hi steve, sorry I am very new to github and wanted to clean things up and make my username/email the github defaults. This version is tested and working properly for me. Not sure why some encodes didn't like "skip_frame:v nokey" but I couldn't get it to work with "skip_frame:v noref" either. Eliminating "skip_frame:v" fully solved the trick, albeit those particular files were much slower to generate thumbnails for.

One more quick thing, changed threads:0 to threads:v and it improved speeds slightly.