### PR TITLE
feat: auto-requeue interrupted jobs on startup

### DIFF
--- a/plex_generate_previews/web/app.py
+++ b/plex_generate_previews/web/app.py
@@ -154,6 +154,40 @@ def get_or_create_flask_secret(config_dir: str) -> str:
     return _derive_secret(random_seed, config_dir)
 
 
+def _requeue_interrupted_on_startup(config_dir: str) -> None:
+    """Auto-requeue jobs that were running or pending when the server last stopped.
+
+    Reads the ``auto_requeue_on_restart`` and ``requeue_max_age_minutes``
+    settings to decide whether and which jobs to re-create.  New jobs are
+    cloned from the originals and started via the normal async path.
+    """
+    try:
+        from .settings_manager import get_settings_manager
+
+        settings = get_settings_manager(config_dir)
+        if not settings.get("auto_requeue_on_restart", True):
+            logger.info("Auto-requeue on restart is disabled")
+            return
+
+        max_age = int(settings.get("requeue_max_age_minutes", 60))
+        job_manager = get_job_manager()
+        new_jobs = job_manager.requeue_interrupted_jobs(max_age_minutes=max_age)
+
+        if not new_jobs:
+            return
+
+        from .routes import _start_job_async
+
+        for job in new_jobs:
+            _start_job_async(job.id, job.config)
+
+        logger.info(
+            f"Auto-requeued {len(new_jobs)} interrupted job(s) on startup"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to auto-requeue interrupted jobs: {e}")
+
+
 def create_app(config_dir: str = None) -> Flask:
     """
     Create and configure the Flask application.
@@ -372,6 +406,9 @@ def create_app(config_dir: str = None) -> Flask:
 
     # Log token on startup
     log_token_on_startup()
+
+    # Auto-requeue jobs that were interrupted by the server restart
+    _requeue_interrupted_on_startup(config_dir)
 
     logger.info(f"Flask app created with config_dir: {config_dir}")
 

--- a/plex_generate_previews/web/jobs.py
+++ b/plex_generate_previews/web/jobs.py
@@ -163,6 +163,7 @@ class JobManager:
 
     def _load_jobs(self) -> None:
         """Load jobs from persistent storage."""
+        self._interrupted_jobs: List[Job] = []
         if os.path.exists(self.jobs_file):
             try:
                 with open(self.jobs_file, "r") as f:
@@ -181,12 +182,20 @@ class JobManager:
                                 job.error = "Job was interrupted by server restart"
                                 job.completed_at = datetime.utcnow().isoformat()
                                 needs_save = True
+                                self._interrupted_jobs.append(job)
+                            elif job.status == JobStatus.PENDING:
+                                self._interrupted_jobs.append(job)
                             self._jobs[job.id] = job
                         except (TypeError, KeyError, ValueError) as job_error:
                             job_id = job_data.get("id", "unknown")
                             logger.warning(f"Failed to load job {job_id}: {job_error}")
                             continue
                 logger.info(f"Loaded {len(self._jobs)} jobs from {self.jobs_file}")
+                if self._interrupted_jobs:
+                    logger.info(
+                        f"Found {len(self._interrupted_jobs)} interrupted/pending job(s) "
+                        f"from previous run"
+                    )
                 if needs_save:
                     self._save_jobs()
             except (json.JSONDecodeError, IOError) as e:
@@ -363,6 +372,95 @@ class JobManager:
             logger.debug(f"Pruned {pruned} old terminal jobs")
         logger.info(f"Created job {job.id} for library {library_name}")
         return job
+
+    def requeue_interrupted_jobs(self, max_age_minutes: int = 60) -> List[Job]:
+        """Create new jobs for any that were interrupted by the last restart.
+
+        For each interrupted job (was running or pending when the server
+        stopped), a **new** job is created with the same configuration.
+        The original job is left in history for auditability.
+
+        Pending jobs that are superseded are cancelled so they don't run
+        alongside the new clone.
+
+        Args:
+            max_age_minutes: Only requeue jobs created within this many
+                minutes of the current time.  Older jobs are considered
+                stale and skipped.  Range: 5 – 1440 (1 day).
+
+        Returns:
+            List of newly created ``Job`` objects ready to be started.
+        """
+        interrupted = getattr(self, "_interrupted_jobs", [])
+        if not interrupted:
+            return []
+
+        max_age_minutes = max(5, min(1440, max_age_minutes))
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=max_age_minutes)
+        requeued: List[Job] = []
+
+        for orig in interrupted:
+            # Check age — skip stale jobs
+            try:
+                created = datetime.fromisoformat(
+                    orig.created_at.replace("Z", "+00:00")
+                )
+                if created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                if created < cutoff:
+                    logger.debug(
+                        f"Skipping requeue of job {orig.id[:8]} — "
+                        f"too old ({orig.created_at})"
+                    )
+                    continue
+            except (ValueError, AttributeError):
+                # Can't parse date — skip to be safe
+                continue
+
+            # Clone config, stripping retry metadata so it starts fresh
+            new_config = dict(orig.config or {})
+            for key in (
+                "is_retry",
+                "retry_delay",
+                "retry_attempt",
+                "max_retries",
+                "parent_job_id",
+            ):
+                new_config.pop(key, None)
+            new_config["requeued_from"] = orig.id
+
+            # Cancel stale pending jobs so they don't also run
+            if orig.status == JobStatus.PENDING:
+                with self._lock:
+                    orig.status = JobStatus.CANCELLED
+                    orig.error = "Superseded by auto-requeue after restart"
+                    orig.completed_at = datetime.now(timezone.utc).isoformat()
+
+            # Create the new job
+            new_job = self.create_job(
+                library_id=orig.library_id,
+                library_name=orig.library_name,
+                config=new_config,
+            )
+            self.add_log(
+                new_job.id,
+                f"INFO - Auto-requeued: original job {orig.id[:8]} was "
+                f"interrupted by server restart",
+            )
+            requeued.append(new_job)
+            logger.info(
+                f"Requeued job {orig.id[:8]} as {new_job.id[:8]} "
+                f"({orig.library_name})"
+            )
+
+        # Persist the cancelled pending jobs
+        if requeued:
+            with self._lock:
+                self._save_jobs()
+
+        # Clear the list so it's not processed again
+        self._interrupted_jobs = []
+        return requeued
 
     def get_job(self, job_id: str) -> Optional[Job]:
         """Get a job by ID."""

--- a/plex_generate_previews/web/routes.py
+++ b/plex_generate_previews/web/routes.py
@@ -1367,6 +1367,8 @@ def get_settings():
             "webhook_retry_count": settings.get("webhook_retry_count", 3),
             "webhook_retry_delay": settings.get("webhook_retry_delay", 30),
             "webhook_secret": "****" if settings.get("webhook_secret") else "",
+            "auto_requeue_on_restart": settings.get("auto_requeue_on_restart", True),
+            "requeue_max_age_minutes": settings.get("requeue_max_age_minutes", 60),
         }
     )
 
@@ -1405,6 +1407,8 @@ def save_settings():
         "webhook_retry_count",
         "webhook_retry_delay",
         "webhook_secret",
+        "auto_requeue_on_restart",
+        "requeue_max_age_minutes",
     ]
 
     updates = {k: v for k, v in data.items() if k in allowed_fields}

--- a/plex_generate_previews/web/templates/webhooks.html
+++ b/plex_generate_previews/web/templates/webhooks.html
@@ -111,6 +111,31 @@
             </div>
             <div class="form-text">Dedicated secret for webhook authentication. Leave empty to use the main API token.</div>
         </div>
+
+        <hr class="my-4">
+
+        <h6 class="mb-3"><i class="bi bi-arrow-repeat me-2"></i>Restart Recovery</h6>
+
+        <div class="mb-3">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="autoRequeueOnRestart" checked>
+                <label class="form-check-label" for="autoRequeueOnRestart">Auto-requeue interrupted jobs on restart</label>
+            </div>
+            <div class="form-text">
+                When the server restarts, automatically re-queue any jobs that were running or waiting.
+                Only jobs created within the configured time window are requeued; older jobs are left as-is.
+            </div>
+        </div>
+
+        <div class="mb-3" id="requeueMaxAgeGroup">
+            <label for="requeueMaxAge" class="form-label">
+                Max requeue age: <strong><span id="requeueMaxAgeValue">60</span> min</strong>
+            </label>
+            <input type="range" class="form-range" id="requeueMaxAge" min="5" max="1440" step="5" value="60">
+            <div class="form-text">
+                How old a job can be to qualify for automatic requeue after restart (5 min &ndash; 24 hours).
+            </div>
+        </div>
     </div>
 </div>
 
@@ -199,7 +224,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadWebhookSettings();
     loadHistory();
 
-    document.querySelectorAll('#webhookEnabled, #webhookDelay, #webhookRetryCount, #webhookRetryDelay, #webhookSecret').forEach(function(el) {
+    document.querySelectorAll('#webhookEnabled, #webhookDelay, #webhookRetryCount, #webhookRetryDelay, #webhookSecret, #autoRequeueOnRestart, #requeueMaxAge').forEach(function(el) {
         el.addEventListener('change', markDirty);
         el.addEventListener('input', markDirty);
     });
@@ -209,6 +234,13 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     document.getElementById('webhookRetryDelay').addEventListener('input', function() {
         document.getElementById('retryDelayValue').textContent = this.value;
+    });
+    document.getElementById('requeueMaxAge').addEventListener('input', function() {
+        document.getElementById('requeueMaxAgeValue').textContent = this.value;
+    });
+    document.getElementById('autoRequeueOnRestart').addEventListener('change', function() {
+        document.getElementById('requeueMaxAgeGroup').style.opacity = this.checked ? '1' : '0.5';
+        document.getElementById('requeueMaxAge').disabled = !this.checked;
     });
 
     setInterval(loadHistory, 10000);
@@ -235,6 +267,14 @@ async function loadWebhookSettings() {
         } else         if (data.webhook_secret === '****') {
             document.getElementById('webhookSecret').placeholder = 'Secret configured (hidden)';
         }
+        // Restart recovery settings
+        const autoRequeue = data.auto_requeue_on_restart !== false;
+        document.getElementById('autoRequeueOnRestart').checked = autoRequeue;
+        const maxAge = Math.min(1440, Math.max(5, parseInt(data.requeue_max_age_minutes, 10) || 60));
+        document.getElementById('requeueMaxAge').value = maxAge;
+        document.getElementById('requeueMaxAgeValue').textContent = maxAge;
+        document.getElementById('requeueMaxAgeGroup').style.opacity = autoRequeue ? '1' : '0.5';
+        document.getElementById('requeueMaxAge').disabled = !autoRequeue;
     } catch (e) {
         console.error('Failed to load webhook settings:', e);
     }
@@ -251,6 +291,8 @@ async function saveWebhookSettings() {
         webhook_delay: parseInt(document.getElementById('webhookDelay').value, 10),
         webhook_retry_count: retryCount,
         webhook_retry_delay: parseInt(document.getElementById('webhookRetryDelay').value, 10) || 30,
+        auto_requeue_on_restart: document.getElementById('autoRequeueOnRestart').checked,
+        requeue_max_age_minutes: parseInt(document.getElementById('requeueMaxAge').value, 10) || 60,
     };
 
     const secretVal = document.getElementById('webhookSecret').value;


### PR DESCRIPTION
## Summary

When the server restarts (update, crash, Docker restart), any jobs that were **running** or **pending** are lost — running jobs get marked as failed, and pending jobs never get a chance to start. The user must manually reprocess each one.

This PR adds **automatic recovery on startup**: interrupted jobs are cloned and re-queued, with configurable controls in the UI.

## What changed

### `jobs.py` — collect interrupted jobs + new `requeue_interrupted_jobs()` method

- `_load_jobs()` now **collects** jobs that were `RUNNING` or `PENDING` at shutdown into `_interrupted_jobs` (in addition to the existing logic that marks running→failed)
- New `requeue_interrupted_jobs(max_age_minutes)` method:
  - Creates new clone jobs preserving the original config (`webhook_paths`, `selected_libraries`, etc.)
  - Strips retry metadata (`is_retry`, `retry_attempt`, etc.) so requeued jobs start fresh
  - Adds `requeued_from: <original_job_id>` to new job config for traceability
  - Cancels stale pending jobs with "Superseded by auto-requeue after restart"
  - Respects a configurable max-age cutoff — jobs older than the threshold are skipped
  - Original failed/cancelled jobs remain in history for auditability

### `app.py` — trigger requeue after app init

- New `_requeue_interrupted_on_startup(config_dir)` function called after `log_token_on_startup()`
- Reads settings to check if feature is enabled and what the max age is
- Starts each requeued job via `_start_job_async()`
- Fully wrapped in try/except — non-fatal if anything goes wrong

### `routes.py` — settings API

- Added `auto_requeue_on_restart` (bool, default `true`) to GET/POST `/api/settings`
- Added `requeue_max_age_minutes` (int, default `60`) to GET/POST `/api/settings`

### `webhooks.html` — UI controls

- New **"Restart Recovery"** section in the Webhooks > Configuration card
- Toggle: "Auto-requeue interrupted jobs on restart"
- Range slider: "Max requeue age" (5 min – 24 hours) with live-updating label
- Slider disables when toggle is off (visual feedback)

## How it works

```
Server stops (crash, update, Docker restart)
    ↓
Jobs in RUNNING state → marked as FAILED (existing behavior)
Jobs in PENDING state → remain as-is
    ↓
Server starts up
    ↓
_load_jobs() collects interrupted + pending jobs
    ↓
_requeue_interrupted_on_startup() checks settings:
  - auto_requeue_on_restart enabled? (default: yes)
  - Job created within max_age window? (default: 60 min)
    ↓
For each qualifying job:
  - Original RUNNING job stays as FAILED in history
  - Original PENDING job cancelled as "Superseded by auto-requeue"
  - New clone job created with same config
  - Started via normal async queue
    ↓
Jobs process normally (webhook paths, selected libraries preserved)
```

## Testing

Tested on a live instance:
- Restarted container while 1 job was running and 1 was pending
- Both were automatically requeued on startup (~1s after boot)
- Original jobs preserved in history with correct error messages
- New jobs ran successfully with original webhook paths
- Settings API correctly loads/saves both new fields
- UI toggle and slider work correctly with live updates

## New Settings

| Setting | Key | Default | Range |
|---|---|---|---|
| Auto-requeue on restart | `auto_requeue_on_restart` | `true` | on/off |
| Max requeue age | `requeue_max_age_minutes` | `60` | 5–1440 min |