### PR TITLE
feat: trigger targeted Plex partial scan on unresolved webhook paths

### DIFF
--- a/plex_generate_previews/plex_client.py
+++ b/plex_generate_previews/plex_client.py
@@ -389,6 +389,138 @@ def _resolve_item_media_type(section_type: str) -> Optional[str]:
     return None
 
 
+def trigger_plex_partial_scan(
+    plex_url: str,
+    plex_token: str,
+    unresolved_paths: List[str],
+    path_mappings: Optional[List[Dict]] = None,
+    verify_ssl: bool = True,
+) -> List[str]:
+    """Trigger targeted Plex library scans for unresolved webhook paths.
+
+    When webhook paths cannot be resolved to Plex items (because Plex hasn't
+    scanned the file yet), this function determines the correct library section
+    and parent folder for each unresolved path and issues a partial scan via
+    ``GET /library/sections/{id}/refresh?path={folder}``.
+
+    This is much faster than a full library scan and allows the subsequent
+    retry attempt to find the item in Plex's database.
+
+    Args:
+        plex_url: Plex server URL (e.g. ``http://localhost:32400``).
+        plex_token: Plex authentication token.
+        unresolved_paths: File paths that could not be resolved to Plex items.
+        path_mappings: Optional path mapping configuration for expanding
+            webhook paths into Plex-native equivalents.
+        verify_ssl: Whether to verify TLS certificates for Plex connections.
+
+    Returns:
+        List of paths for which a scan was successfully triggered.
+    """
+    if not unresolved_paths:
+        return []
+
+    if not verify_ssl:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    scanned: List[str] = []
+
+    try:
+        resp = requests.get(
+            f"{plex_url.rstrip('/')}/library/sections",
+            headers={"X-Plex-Token": plex_token, "Accept": "application/json"},
+            timeout=10,
+            verify=verify_ssl,
+        )
+        resp.raise_for_status()
+        sections = resp.json().get("MediaContainer", {}).get("Directory", [])
+    except requests.RequestException as e:
+        logger.warning(f"Could not fetch Plex library sections for partial scan: {e}")
+        return []
+
+    # Build lookup: normalised location prefix -> (section_key, raw_location),
+    # sorted longest-first so more-specific mounts match before broader ones.
+    section_locations: List[Tuple[str, str, str]] = []
+    for section in sections:
+        section_key = str(section.get("key", ""))
+        for loc in section.get("Location", []):
+            loc_path = loc.get("path", "")
+            if loc_path:
+                norm = loc_path.rstrip("/") + "/"
+                section_locations.append((norm, section_key, loc_path))
+    section_locations.sort(key=lambda t: len(t[0]), reverse=True)
+
+    for unresolved in unresolved_paths:
+        candidates = (
+            expand_path_mapping_candidates(unresolved, path_mappings)
+            if path_mappings
+            else [unresolved]
+        )
+        scan_targets: Set[Tuple[str, str]] = set()
+
+        for candidate in candidates:
+            norm_candidate = candidate.rstrip("/") + "/"
+            for loc_prefix, section_key, _raw_loc in section_locations:
+                if not norm_candidate.startswith(loc_prefix):
+                    continue
+
+                # Use the top-level subfolder (series or movie folder).
+                rel = candidate[len(loc_prefix.rstrip("/")) :]
+                parts = [p for p in rel.split("/") if p]
+                scan_folder = (
+                    loc_prefix.rstrip("/") + "/" + parts[0]
+                    if len(parts) >= 2
+                    else loc_prefix.rstrip("/")
+                )
+                scan_targets.add((section_key, scan_folder))
+                break  # First prefix match is best (sorted longest-first)
+
+        if not scan_targets:
+            logger.debug(
+                f"No matching Plex library section found for unresolved path: {unresolved}"
+            )
+            continue
+
+        triggered = False
+        for section_key, scan_folder in sorted(scan_targets):
+            try:
+                scan_resp = requests.get(
+                    f"{plex_url.rstrip('/')}/library/sections/{section_key}/refresh",
+                    params={"path": scan_folder},
+                    headers={"X-Plex-Token": plex_token},
+                    timeout=10,
+                    verify=verify_ssl,
+                )
+                if scan_resp.status_code == 200:
+                    logger.info(
+                        f"Triggered Plex partial scan for section {section_key}: {scan_folder}"
+                    )
+                    triggered = True
+                else:
+                    logger.warning(
+                        f"Plex partial scan returned HTTP {scan_resp.status_code} "
+                        f"for section {section_key}, path {scan_folder}"
+                    )
+            except requests.RequestException as e:
+                logger.warning(
+                    f"Failed to trigger Plex partial scan for {scan_folder}: {e}"
+                )
+
+        if triggered:
+            scanned.append(unresolved)
+        else:
+            logger.debug(
+                f"Matching Plex sections found but partial scans did not succeed for: {unresolved}"
+            )
+
+    if scanned:
+        logger.info(
+            f"Triggered Plex partial scans for {len(scanned)}/{len(unresolved_paths)} unresolved path(s)"
+        )
+
+    return scanned
+
+
 @dataclass
 class WebhookResolutionResult:
     """Result of resolving webhook file paths to Plex media items."""

--- a/plex_generate_previews/web/routes.py
+++ b/plex_generate_previews/web/routes.py
@@ -2183,6 +2183,36 @@ def _start_job_async(job_id: str, config_overrides: dict = None):
                         )
                         return rj.id
 
+                    # Trigger targeted Plex partial scans for unresolved
+                    # paths *before* spawning retry jobs.  This nudges Plex to
+                    # index newly-arrived files so the next attempt can resolve
+                    # them.
+                    if (
+                        unresolved_paths
+                        and not is_retry
+                        and not (result.get("cancelled") or status_value == "cancelled")
+                    ):
+                        try:
+                            from ..plex_client import trigger_plex_partial_scan
+
+                            scan_results = trigger_plex_partial_scan(
+                                plex_url=config.plex_url,
+                                plex_token=config.plex_token,
+                                unresolved_paths=unresolved_paths,
+                                path_mappings=config.path_mappings,
+                                verify_ssl=config.plex_verify_ssl,
+                            )
+                            if scan_results:
+                                job_manager.add_log(
+                                    job_id,
+                                    f"INFO - Triggered Plex scan for "
+                                    f"{len(scan_results)} unresolved path(s)",
+                                )
+                        except Exception as scan_exc:  # noqa: BLE001
+                            logger.debug(
+                                f"Plex partial scan attempt failed (non-fatal): {scan_exc}"
+                            )
+
                     # Determine whether to spawn retries for unresolved paths.
                     # This must run regardless of whether processing had failures,
                     # so unresolved paths are never silently dropped.

--- a/tests/test_plex_client.py
+++ b/tests/test_plex_client.py
@@ -7,7 +7,7 @@ and duplicate filtering.
 
 import pytest
 import xml.etree.ElementTree as ET
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 import requests
 
 from plex_generate_previews.plex_client import (
@@ -16,6 +16,7 @@ from plex_generate_previews.plex_client import (
     filter_duplicate_locations,
     get_library_sections,
     get_media_items_by_paths,
+    trigger_plex_partial_scan,
     WebhookResolutionResult,
 )
 
@@ -132,6 +133,240 @@ class TestRetryPlexCall:
 
         # Should only try once (no retry for non-XML errors)
         assert mock_func.call_count == 1
+
+
+class TestTriggerPlexPartialScan:
+    """Test targeted Plex partial scan behavior for unresolved webhook paths."""
+
+    @patch("requests.get")
+    def test_empty_input_returns_empty_without_http_calls(self, mock_get):
+        """Empty unresolved path list should short-circuit."""
+        result = trigger_plex_partial_scan(
+            plex_url="http://plex:32400",
+            plex_token="token",
+            unresolved_paths=[],
+        )
+
+        assert result == []
+        mock_get.assert_not_called()
+
+    @patch("requests.get")
+    def test_longest_prefix_match_wins(self, mock_get):
+        """More specific section root should be chosen before a broader one."""
+        sections_response = MagicMock()
+        sections_response.raise_for_status = MagicMock()
+        sections_response.json.return_value = {
+            "MediaContainer": {
+                "Directory": [
+                    {"key": "1", "Location": [{"path": "/data"}]},
+                    {"key": "2", "Location": [{"path": "/data/tv"}]},
+                ]
+            }
+        }
+        refresh_response = MagicMock(status_code=200)
+        mock_get.side_effect = [sections_response, refresh_response]
+
+        result = trigger_plex_partial_scan(
+            plex_url="http://plex:32400",
+            plex_token="token",
+            unresolved_paths=["/data/tv/Show/Season 01/Episode 01.mkv"],
+        )
+
+        assert result == ["/data/tv/Show/Season 01/Episode 01.mkv"]
+        assert mock_get.call_args_list[1] == call(
+            "http://plex:32400/library/sections/2/refresh",
+            params={"path": "/data/tv/Show"},
+            headers={"X-Plex-Token": "token"},
+            timeout=10,
+            verify=True,
+        )
+
+    @patch("requests.get")
+    def test_path_mapping_expansion_triggers_scan_for_mapped_plex_path(self, mock_get):
+        """Webhook aliases should expand into Plex-native paths before scanning."""
+        sections_response = MagicMock()
+        sections_response.raise_for_status = MagicMock()
+        sections_response.json.return_value = {
+            "MediaContainer": {
+                "Directory": [
+                    {"key": "9", "Location": [{"path": "/data_16tb/tv"}]},
+                ]
+            }
+        }
+        refresh_response = MagicMock(status_code=200)
+        mock_get.side_effect = [sections_response, refresh_response]
+
+        result = trigger_plex_partial_scan(
+            plex_url="https://plex.example:32400",
+            plex_token="token",
+            unresolved_paths=["/data/tv/Example Show/Season 01/S01E01.mkv"],
+            path_mappings=[
+                {
+                    "plex_prefix": "/data_16tb",
+                    "local_prefix": "/mnt/media",
+                    "webhook_prefixes": ["/data"],
+                }
+            ],
+            verify_ssl=False,
+        )
+
+        assert result == ["/data/tv/Example Show/Season 01/S01E01.mkv"]
+        assert mock_get.call_args_list[0].kwargs["verify"] is False
+        assert mock_get.call_args_list[1] == call(
+            "https://plex.example:32400/library/sections/9/refresh",
+            params={"path": "/data_16tb/tv/Example Show"},
+            headers={"X-Plex-Token": "token"},
+            timeout=10,
+            verify=False,
+        )
+
+    @pytest.mark.parametrize(
+        ("unresolved_path", "location_path", "expected_scan_folder"),
+        [
+            (
+                "/data/tv/Test Show/Season 01/Test Show - S01E01.mkv",
+                "/data/tv",
+                "/data/tv/Test Show",
+            ),
+            (
+                "/data/movies/Test Movie (2024)/Test Movie (2024).mkv",
+                "/data/movies",
+                "/data/movies/Test Movie (2024)",
+            ),
+        ],
+    )
+    @patch("requests.get")
+    def test_scan_folder_targets_series_or_movie_root(
+        self,
+        mock_get,
+        unresolved_path,
+        location_path,
+        expected_scan_folder,
+    ):
+        """Partial scan should target the top-level show/movie folder."""
+        sections_response = MagicMock()
+        sections_response.raise_for_status = MagicMock()
+        sections_response.json.return_value = {
+            "MediaContainer": {
+                "Directory": [{"key": "3", "Location": [{"path": location_path}]}]
+            }
+        }
+        refresh_response = MagicMock(status_code=200)
+        mock_get.side_effect = [sections_response, refresh_response]
+
+        result = trigger_plex_partial_scan(
+            plex_url="http://plex:32400",
+            plex_token="token",
+            unresolved_paths=[unresolved_path],
+        )
+
+        assert result == [unresolved_path]
+        assert mock_get.call_args_list[1].kwargs["params"] == {
+            "path": expected_scan_folder
+        }
+
+    @patch("requests.get")
+    def test_sections_request_error_returns_empty(self, mock_get):
+        """Section lookup failures should be logged and treated as non-fatal."""
+        mock_get.side_effect = requests.RequestException("boom")
+
+        result = trigger_plex_partial_scan(
+            plex_url="http://plex:32400",
+            plex_token="token",
+            unresolved_paths=["/data/tv/Show/Season 01/Episode 01.mkv"],
+        )
+
+        assert result == []
+
+    @patch("requests.get")
+    def test_refresh_http_error_is_handled_gracefully(self, mock_get):
+        """Non-200 refresh responses should not be reported as scanned."""
+        sections_response = MagicMock()
+        sections_response.raise_for_status = MagicMock()
+        sections_response.json.return_value = {
+            "MediaContainer": {
+                "Directory": [{"key": "7", "Location": [{"path": "/data/movies"}]}]
+            }
+        }
+        refresh_response = MagicMock(status_code=500)
+        mock_get.side_effect = [sections_response, refresh_response]
+
+        result = trigger_plex_partial_scan(
+            plex_url="http://plex:32400",
+            plex_token="token",
+            unresolved_paths=["/data/movies/Broken Movie/Broken Movie.mkv"],
+        )
+
+        assert result == []
+
+    @patch("requests.get")
+    def test_multi_drive_scans_all_matching_candidates(self, mock_get):
+        """Expanded path mappings should scan every matching Plex drive root."""
+        sections_response = MagicMock()
+        sections_response.raise_for_status = MagicMock()
+        sections_response.json.return_value = {
+            "MediaContainer": {
+                "Directory": [
+                    {"key": "1", "Location": [{"path": "/drive1/tv"}]},
+                    {"key": "2", "Location": [{"path": "/drive2/tv"}]},
+                    {"key": "3", "Location": [{"path": "/drive3/tv"}]},
+                ]
+            }
+        }
+        mock_get.side_effect = [
+            sections_response,
+            MagicMock(status_code=200),
+            MagicMock(status_code=200),
+            MagicMock(status_code=200),
+        ]
+
+        result = trigger_plex_partial_scan(
+            plex_url="http://plex:32400",
+            plex_token="token",
+            unresolved_paths=["/data/tv/Test Show/Season 01/Test Show - S01E01.mkv"],
+            path_mappings=[
+                {
+                    "plex_prefix": "/drive1",
+                    "local_prefix": "/drive1",
+                    "webhook_prefixes": ["/data"],
+                },
+                {
+                    "plex_prefix": "/drive2",
+                    "local_prefix": "/drive2",
+                    "webhook_prefixes": ["/data"],
+                },
+                {
+                    "plex_prefix": "/drive3",
+                    "local_prefix": "/drive3",
+                    "webhook_prefixes": ["/data"],
+                },
+            ],
+        )
+
+        assert result == ["/data/tv/Test Show/Season 01/Test Show - S01E01.mkv"]
+        assert mock_get.call_args_list[1:] == [
+            call(
+                "http://plex:32400/library/sections/1/refresh",
+                params={"path": "/drive1/tv/Test Show"},
+                headers={"X-Plex-Token": "token"},
+                timeout=10,
+                verify=True,
+            ),
+            call(
+                "http://plex:32400/library/sections/2/refresh",
+                params={"path": "/drive2/tv/Test Show"},
+                headers={"X-Plex-Token": "token"},
+                timeout=10,
+                verify=True,
+            ),
+            call(
+                "http://plex:32400/library/sections/3/refresh",
+                params={"path": "/drive3/tv/Test Show"},
+                headers={"X-Plex-Token": "token"},
+                timeout=10,
+                verify=True,
+            ),
+        ]
 
 
 class TestFilterDuplicateLocations:


### PR DESCRIPTION
## Summary

- Adds `trigger_plex_partial_scan()` to nudge Plex into indexing newly-arrived files when a webhook path can't be resolved
- Fires a targeted `GET /library/sections/{id}/refresh?path={folder}` for each matching Plex library root -- fast (~1-2s per folder) and non-destructive
- Correctly handles **multi-drive setups**: expands webhook paths through all configured path mappings and scans every matching drive, not just the first one
- Only triggers on the **initial webhook job**, not on subsequent retries
- Respects `plex_verify_ssl` setting for all HTTP calls
- Fully wrapped in try/except -- scan failures are non-fatal and never block preview generation

## Files changed

- `plex_generate_previews/plex_client.py` -- new `trigger_plex_partial_scan()` function
- `plex_generate_previews/web/routes.py` -- call scan before spawning retry jobs (guarded by `not is_retry`)
- `tests/test_plex_client.py` -- 8 new tests covering empty input, prefix matching, path mapping expansion, scan folder extraction, error handling, and multi-drive fan-out

## Test plan

- [x] Full test suite passes (864 tests, 80.82% coverage)
- [x] Ruff lint clean

Replaces PR #162 with fixes for SSL, scan-once, multi-drive, and test coverage.