### PR TITLE
Cap FFmpeg global thread and filter_thread count

### DIFF
--- a/plex_generate_previews/media_processing.py
+++ b/plex_generate_previews/media_processing.py
@@ -614,6 +614,10 @@ def heuristic_allows_skip(ffmpeg_path: str, video_file: str) -> bool:
         "explode",  # fail fast on decode issues
         "-skip_frame:v",
         "nokey",
+        "-threads",
+        "2",
+        "-filter_threads",
+        "2",
         "-threads:v",
         "1",
         "-i",
@@ -764,6 +768,10 @@ def generate_images(
             config.ffmpeg_path,
             "-loglevel",
             "info",
+            "-threads",
+            "2",
+            "-filter_threads",
+            "2",
             "-threads:v",
             "1",
         ]


### PR DESCRIPTION
## Summary

- FFmpeg's global `-threads` defaults to `0` (auto), spawning ~71 threads per worker process
- The existing `-threads:v 1` only limits video decode threads — the global thread pool and filter graph threads remain unbounded
- On a 16-thread CPU (5800X) with 2+ GPU workers, this saturates all cores and starves co-located services (Plex transcoding, Sonarr/Radarr exporters)
- Adds `-threads 2` and `-filter_threads 2` before `-threads:v 1` at both FFmpeg invocation sites, reducing per-process thread count from ~71 to ~29

The remaining ~29 threads are CUDA runtime threads that can't be controlled via FFmpeg flags.

## Test plan

- [ ] Run a bulk generation job with 2+ GPU workers and verify CPU usage stays reasonable
- [ ] Verify BIF files are still generated correctly (timeline scrubbing works in Plex)
- [ ] Monitor with `htop` — thread count per ffmpeg process should be ~29 instead of ~71

🤖 Generated with [Claude Code](https://claude.com/claude-code)