### PR TITLE
perf: fix slow Settings and Webhooks page loads

### DIFF
--- a/plex_generate_previews/web/app.py
+++ b/plex_generate_previews/web/app.py
@@ -155,6 +155,38 @@ def get_or_create_flask_secret(config_dir: str) -> str:
     return _derive_secret(random_seed, config_dir)
 
 
+def _prewarm_caches() -> None:
+    """Pre-warm GPU detection and version caches in background threads.
+
+    GPU detection runs FFmpeg subprocess tests and can take several seconds.
+    Version checks hit the GitHub API with network timeouts.  Running both
+    eagerly at startup means the first page load returns instantly instead
+    of blocking on these slow operations.
+    """
+    import threading
+
+    def _warm_gpu() -> None:
+        try:
+            from .routes._helpers import _ensure_gpu_cache
+
+            _ensure_gpu_cache()
+            logger.debug("GPU cache pre-warmed")
+        except Exception as exc:
+            logger.debug(f"GPU cache pre-warm failed (non-fatal): {exc}")
+
+    def _warm_version() -> None:
+        try:
+            from .routes.api_system import _get_version_info
+
+            _get_version_info()
+            logger.debug("Version cache pre-warmed")
+        except Exception as exc:
+            logger.debug(f"Version cache pre-warm failed (non-fatal): {exc}")
+
+    threading.Thread(target=_warm_gpu, name="prewarm-gpu", daemon=True).start()
+    threading.Thread(target=_warm_version, name="prewarm-version", daemon=True).start()
+
+
 def _requeue_interrupted_on_startup(config_dir: str) -> None:
     """Auto-requeue jobs that were running or pending when the server last stopped.
 
@@ -437,6 +469,10 @@ def create_app(config_dir: str = None) -> Flask:
 
     # Auto-requeue jobs that were interrupted by the server restart
     _requeue_interrupted_on_startup(config_dir)
+
+    # Pre-warm GPU and version caches in background threads so the first
+    # page load doesn't block on GPU detection or GitHub API calls.
+    _prewarm_caches()
 
     logger.info(f"Flask app created with config_dir: {config_dir}")
 

--- a/plex_generate_previews/web/routes/__init__.py
+++ b/plex_generate_previews/web/routes/__init__.py
@@ -30,6 +30,6 @@ from ._helpers import (  # noqa: E402, F401
     clear_gpu_cache,
     limiter,
 )
-from .api_system import _fetch_libraries_via_http  # noqa: E402, F401
+from .api_system import _fetch_libraries_via_http, clear_library_cache  # noqa: E402, F401
 from .job_runner import _start_job_async  # noqa: E402, F401
 from .socketio_handlers import register_socketio_handlers  # noqa: E402, F401

--- a/plex_generate_previews/web/routes/api_settings.py
+++ b/plex_generate_previews/web/routes/api_settings.py
@@ -145,6 +145,14 @@ def save_settings():
         if "gpu_config" in updates:
             _reconcile_live_gpu_workers(settings)
 
+        # Invalidate the Plex library cache when connection details change
+        # so the next libraries request fetches fresh data.
+        plex_fields = {"plex_url", "plex_token", "plex_verify_ssl"}
+        if plex_fields & updates.keys():
+            from .api_system import clear_library_cache
+
+            clear_library_cache()
+
         log_fields = {"log_level", "log_rotation_size", "log_retention_count"}
         if log_fields & updates.keys():
             from ...logging_config import setup_logging

--- a/plex_generate_previews/web/routes/api_system.py
+++ b/plex_generate_previews/web/routes/api_system.py
@@ -440,6 +440,21 @@ def dismiss_whats_new():
     return jsonify({"ok": True})
 
 
+_library_cache: dict = {"result": None, "fetched_at": 0.0}
+_library_cache_lock = threading.Lock()
+_LIBRARY_CACHE_TTL = 300  # 5 minutes
+
+
+def clear_library_cache() -> None:
+    """Reset the Plex library cache.
+
+    Useful for tests and when settings change (e.g. Plex URL updated).
+    """
+    with _library_cache_lock:
+        _library_cache["result"] = None
+        _library_cache["fetched_at"] = 0.0
+
+
 def _fetch_libraries_via_http(
     plex_url: str,
     plex_token: str,
@@ -490,6 +505,9 @@ def get_libraries():
 
     Accepts optional query params 'url' and 'token' to override saved
     settings (used during setup wizard before config is persisted).
+
+    Results are cached for 5 minutes when using saved credentials to
+    avoid hitting the Plex server on every settings page load.
     """
     try:
         import requests as req_lib
@@ -503,6 +521,9 @@ def get_libraries():
         verify_ssl = _param_to_bool(
             request.args.get("verify_ssl"), settings.plex_verify_ssl
         )
+
+        # Track whether explicit overrides were provided (setup wizard)
+        has_overrides = bool(plex_url or plex_token)
 
         if not plex_url or not plex_token:
             plex_url = plex_url or settings.plex_url
@@ -545,11 +566,25 @@ def get_libraries():
                     }
                 ), 400
 
+        # Use cached result when loading with saved credentials (not
+        # during setup wizard where explicit overrides are provided).
+        if not has_overrides:
+            with _library_cache_lock:
+                cached = _library_cache["result"]
+                age = time.monotonic() - _library_cache["fetched_at"]
+            if cached is not None and age < _LIBRARY_CACHE_TTL:
+                return jsonify({"libraries": cached})
+
         libraries = _fetch_libraries_via_http(
             plex_url,
             plex_token,
             verify_ssl=verify_ssl,
         )
+
+        if not has_overrides:
+            with _library_cache_lock:
+                _library_cache["result"] = libraries
+                _library_cache["fetched_at"] = time.monotonic()
 
         return jsonify({"libraries": libraries})
 

--- a/plex_generate_previews/web/static/js/app.js
+++ b/plex_generate_previews/web/static/js/app.js
@@ -2268,6 +2268,5 @@ function _renderMarkdownBasic(md) {
     return html;
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-    setTimeout(checkWhatsNew, 2000);
-});
+// checkWhatsNew() is called from the dashboard page (index.html) only,
+// to avoid hitting the GitHub API on every page navigation.

--- a/plex_generate_previews/web/templates/index.html
+++ b/plex_generate_previews/web/templates/index.html
@@ -584,6 +584,7 @@
         // runs expensive GPU detection subprocesses).
         initDashboard();
         loadDashboardVersionInfo();
+        setTimeout(checkWhatsNew, 2000);
 
         document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) {
             new bootstrap.Tooltip(el);

--- a/plex_generate_previews/web/templates/settings.html
+++ b/plex_generate_previews/web/templates/settings.html
@@ -434,9 +434,15 @@
 <script src="{{ url_for('static', filename='js/plex-auth.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    loadSettings().then(() => loadGpuInfo());
-    loadLibraries();
-    loadVersionInfo();
+    // Fire all API calls concurrently to avoid a sequential waterfall.
+    // GPU rendering needs window._gpuConfig from settings, so we start
+    // the GPU status fetch in parallel but render after both resolve.
+    const gpuPromise = fetchGpuStatus();
+    Promise.all([
+        loadSettings().then(() => renderGpuFromFetch(gpuPromise)),
+        loadLibraries(),
+        loadVersionInfo(),
+    ]);
 
     // Track changes
     document.querySelectorAll('input, select').forEach(el => {
@@ -700,11 +706,13 @@ async function loadLibraries() {
     }
 }
 
-async function loadGpuInfo() {
-    try {
-        const response = await fetch('/api/system/status');
-        const data = await response.json();
+function fetchGpuStatus() {
+    return fetch('/api/system/status').then(r => r.json());
+}
 
+async function renderGpuFromFetch(gpuPromise) {
+    try {
+        const data = await gpuPromise;
         document.getElementById('gpuDetecting').classList.add('d-none');
 
         if (data.gpus && data.gpus.length > 0) {
@@ -721,6 +729,11 @@ async function loadGpuInfo() {
             '<div class="alert alert-danger mb-0">' +
             '<i class="bi bi-x-circle me-2"></i>Failed to detect GPUs.</div>';
     }
+}
+
+// Kept for the rescan button which doesn't need parallel loading.
+async function loadGpuInfo() {
+    return renderGpuFromFetch(fetchGpuStatus());
 }
 
 function renderGpuConfigPanel(detectedGpus, savedConfig) {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -223,3 +223,56 @@ class TestRequeueInterruptedOnStartup:
             max_age_minutes=45
         )
         mock_start_job.assert_called_once_with("job-123", {"foo": "bar"})
+
+
+class TestPrewarmCaches:
+    """Test background cache pre-warming at startup."""
+
+    @patch("plex_generate_previews.web.app._prewarm_caches")
+    def test_prewarm_called_during_create_app(self, mock_prewarm):
+        """create_app invokes _prewarm_caches so GPU/version caches are warm."""
+        import json
+        import os
+
+        from plex_generate_previews.web.app import create_app
+
+        config_dir = "/tmp/test_prewarm"
+        os.makedirs(config_dir, exist_ok=True)
+        auth_file = os.path.join(config_dir, "auth.json")
+        with open(auth_file, "w") as f:
+            json.dump({"token": "test-token-12345678"}, f)
+        settings_file = os.path.join(config_dir, "settings.json")
+        with open(settings_file, "w") as f:
+            json.dump({"setup_complete": True}, f)
+
+        with patch.dict(
+            os.environ,
+            {"CONFIG_DIR": config_dir, "WEB_AUTH_TOKEN": "test-token-12345678"},
+        ):
+            create_app(config_dir=config_dir)
+            mock_prewarm.assert_called_once()
+
+        import shutil
+
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+    @patch(
+        "plex_generate_previews.web.routes.api_system._get_version_info",
+        return_value={"current_version": "1.0.0"},
+    )
+    @patch("plex_generate_previews.web.routes._helpers._ensure_gpu_cache")
+    def test_prewarm_calls_gpu_and_version(self, mock_gpu, mock_version):
+        """_prewarm_caches starts threads for GPU and version caches."""
+        import threading
+
+        from plex_generate_previews.web.app import _prewarm_caches
+
+        _prewarm_caches()
+
+        # Wait briefly for daemon threads to finish
+        for t in threading.enumerate():
+            if t.name in ("prewarm-gpu", "prewarm-version"):
+                t.join(timeout=5)
+
+        mock_gpu.assert_called_once()
+        mock_version.assert_called_once()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -36,10 +36,11 @@ def _reset_singletons():
 
     with sched_mod._schedule_lock:
         sched_mod._schedule_manager = None
-    # Clear GPU detection cache
-    from plex_generate_previews.web.routes import clear_gpu_cache
+    # Clear GPU detection and library caches
+    from plex_generate_previews.web.routes import clear_gpu_cache, clear_library_cache
 
     clear_gpu_cache()
+    clear_library_cache()
     yield
     reset_settings_manager()
     with jobs_mod._job_lock:
@@ -47,6 +48,7 @@ def _reset_singletons():
     with sched_mod._schedule_lock:
         sched_mod._schedule_manager = None
     clear_gpu_cache()
+    clear_library_cache()
 
 
 @pytest.fixture()
@@ -2605,3 +2607,72 @@ class TestParamToBool:
         )
         assert resp.status_code == 200
         assert mock_get.call_args.kwargs["verify"] is False
+
+
+# ---------------------------------------------------------------------------
+# Library cache
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryCache:
+    """Test Plex library caching behaviour."""
+
+    @patch("plex_generate_previews.web.routes.api_system._fetch_libraries_via_http")
+    def test_libraries_cached_on_second_call(self, mock_fetch, client):
+        """Second call to /api/libraries returns cached data without re-fetching."""
+        from plex_generate_previews.web.settings_manager import get_settings_manager
+
+        sm = get_settings_manager()
+        sm.set("plex_url", "http://plex:32400")
+        sm.set("plex_token", "test-token")
+        mock_fetch.return_value = [{"id": "1", "name": "Movies", "type": "movie"}]
+
+        resp1 = client.get("/api/libraries", headers=_api_headers())
+        resp2 = client.get("/api/libraries", headers=_api_headers())
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        assert resp2.get_json()["libraries"][0]["name"] == "Movies"
+        # Only one fetch — second call served from cache
+        assert mock_fetch.call_count == 1
+
+    @patch("plex_generate_previews.web.routes.api_system._fetch_libraries_via_http")
+    def test_cache_bypassed_with_explicit_url(self, mock_fetch, client):
+        """Explicit url/token query params bypass the library cache."""
+        from plex_generate_previews.web.settings_manager import get_settings_manager
+
+        sm = get_settings_manager()
+        sm.set("plex_url", "http://plex:32400")
+        sm.set("plex_token", "test-token")
+        mock_fetch.return_value = [{"id": "1", "name": "Movies", "type": "movie"}]
+
+        # First call populates cache
+        client.get("/api/libraries", headers=_api_headers())
+        # Second call with explicit overrides should bypass cache
+        client.get(
+            "/api/libraries?url=http://other:32400&token=tok",
+            headers=_api_headers(),
+        )
+        assert mock_fetch.call_count == 2
+
+    @patch("plex_generate_previews.web.routes.api_system._fetch_libraries_via_http")
+    def test_cache_invalidated_on_plex_url_change(self, mock_fetch, client):
+        """Saving a new plex_url clears the library cache."""
+        from plex_generate_previews.web.settings_manager import get_settings_manager
+
+        sm = get_settings_manager()
+        sm.set("plex_url", "http://plex:32400")
+        sm.set("plex_token", "test-token")
+        mock_fetch.return_value = [{"id": "1", "name": "Movies", "type": "movie"}]
+
+        client.get("/api/libraries", headers=_api_headers())
+        assert mock_fetch.call_count == 1
+
+        # Changing plex_url should invalidate the cache
+        client.post(
+            "/api/settings",
+            headers=_api_headers(),
+            json={"plex_url": "http://new-plex:32400"},
+        )
+        client.get("/api/libraries", headers=_api_headers())
+        assert mock_fetch.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #187 — Settings and Webhooks pages are painfully slow to load in Docker/k8s deployments due to a waterfall of blocking external API calls.

- **Pre-warm GPU + version caches on startup** — background threads run GPU detection (FFmpeg subprocess tests) and GitHub version check at app startup so the first page load hits warm caches
- **Cache Plex libraries with 5-min TTL** — `/api/libraries` previously hit the Plex server on every settings page visit with no caching; now cached for 5 minutes (invalidated when Plex connection settings change)
- **Parallelize settings page API calls** — GPU status fetch starts concurrently with settings load instead of waiting sequentially (`.then()`)
- **Move `checkWhatsNew()` to dashboard only** — was running on every page via `app.js`, causing parasitic GitHub API calls when navigating to settings/webhooks/logs

## Test plan

- [x] All 1090 existing tests pass
- [x] 5 new tests added:
  - `TestLibraryCache::test_libraries_cached_on_second_call` — verifies second fetch serves from cache
  - `TestLibraryCache::test_cache_bypassed_with_explicit_url` — setup wizard overrides bypass cache
  - `TestLibraryCache::test_cache_invalidated_on_plex_url_change` — saving new plex_url clears cache
  - `TestPrewarmCaches::test_prewarm_called_during_create_app` — verifies startup hook runs
  - `TestPrewarmCaches::test_prewarm_calls_gpu_and_version` — verifies both caches are warmed
- [x] `ruff check` and `ruff format` pass
- [ ] Manual test in Docker: settings page loads near-instantly on second visit
- [ ] Manual test: what's-new modal still appears on dashboard after version update

🤖 Generated with [Claude Code](https://claude.com/claude-code)