### PR TITLE
chore: add encoding= to open() and type hints (16 files)

### DIFF
--- a/plex_generate_previews/config.py
+++ b/plex_generate_previews/config.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from .utils import is_docker_environment
+from pathlib import Path
 
 
 class ConfigValidationError(Exception):
@@ -40,7 +41,7 @@ if "ROCM_PATH" not in os.environ:
 
 def get_config_value(
     cli_args, field_name: str, env_key: str, default, value_type: type = str
-):
+) -> bool:
     """Get configuration value with proper precedence: CLI args > env vars > defaults.
 
     Args:
@@ -533,7 +534,7 @@ class Config:
         return f"Config({', '.join(fields)})"
 
 
-def show_docker_help():
+def show_docker_help() -> None:
     """Show help message pointing users to the web UI for configuration."""
     logger.info("🐳 Docker Environment Detected")
     logger.info("=" * 80)
@@ -1032,7 +1033,7 @@ _cached_config: Optional[Config] = None
 _cached_config_mtime: Optional[float] = None
 
 
-def get_cached_config():
+def get_cached_config() -> None:
     """Return config, using cache if settings.json has not changed since last load.
 
     Use this for read-only config access (e.g. API that returns current config).

--- a/plex_generate_previews/logging_config.py
+++ b/plex_generate_previews/logging_config.py
@@ -135,7 +135,7 @@ def setup_logging(
     console: Console = None,
     log_format: str = None,
     rotation: str = "10 MB",
-    retention=5,
+    retention: int=5,
 ) -> None:
     """Create (or replace) the managed loguru handlers.
 
@@ -257,7 +257,7 @@ class SocketIOLogBroadcaster:
     def __init__(self, socketio) -> None:
         self._socketio = socketio
 
-    def sink(self, message) -> None:
+    def sink(self, message: str) -> None:
         """Loguru sink callable — build payload and emit."""
         record = message.record
         level_name = record["level"].name

--- a/plex_generate_previews/processing.py
+++ b/plex_generate_previews/processing.py
@@ -16,7 +16,7 @@ from .worker import WorkerPool
 
 
 def run_processing(
-    config,
+    config: dict,
     selected_gpus,
     progress_callback=None,
     worker_callback=None,
@@ -24,10 +24,10 @@ def run_processing(
     cancel_check=None,
     pause_check=None,
     worker_pool_callback=None,
-    job_id=None,
+    job_id: int=None,
     on_dispatch_start=None,
-    priority=None,
-):
+    priority: int=None,
+) -> None:
     """Run the main processing workflow.
 
     Args:

--- a/plex_generate_previews/utils.py
+++ b/plex_generate_previews/utils.py
@@ -116,7 +116,7 @@ def is_macos() -> bool:
 
 
 def sanitize_path(path: str) -> str:
-    """Sanitize file path for cross-platform compatibility.
+    r"""Sanitize file path for cross-platform compatibility.
 
     On Windows:
     - Converts forward slashes to backslashes

--- a/plex_generate_previews/web/app.py
+++ b/plex_generate_previews/web/app.py
@@ -29,7 +29,7 @@ socketio = SocketIO()
 csrf = CSRFProtect()
 
 
-def run_scheduled_job(library_id=None, library_name="", config=None, priority=None):
+def run_scheduled_job(library_id: int=None, library_name: str="", config: dict=None, priority: int=None) -> None:
     """Callback for running scheduled jobs.
 
     Must be at module level (not inside create_app) so APScheduler
@@ -497,7 +497,7 @@ def create_app(config_dir: str = None) -> Flask:
     return app
 
 
-def run_server(host: str = "0.0.0.0", port: int = 8080, debug: bool = False):
+def run_server(host: str = "0.0.0.0", port: int = 8080, debug: bool = False) -> None:
     """Run the web server with SocketIO.
 
     In production (Docker), use gunicorn via ``wrapper.sh`` instead.

--- a/plex_generate_previews/web/auth.py
+++ b/plex_generate_previews/web/auth.py
@@ -35,7 +35,7 @@ def load_auth_config() -> dict:
     """Load authentication configuration from file."""
     if os.path.exists(AUTH_FILE):
         try:
-            with open(AUTH_FILE, "r") as f:
+            with open(AUTH_FILE, "r", encoding="utf-8") as f:
                 return json.load(f)
         except (json.JSONDecodeError, IOError) as e:
             logger.warning(f"Failed to load auth config: {e}")

--- a/plex_generate_previews/web/jobs.py
+++ b/plex_generate_previews/web/jobs.py
@@ -204,7 +204,7 @@ class JobManager:
         """Load jobs from persistent storage."""
         if os.path.exists(self.jobs_file):
             try:
-                with open(self.jobs_file, "r") as f:
+                with open(self.jobs_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     needs_save = False
                     for job_data in data.get("jobs", []):
@@ -770,7 +770,7 @@ class JobManager:
             self._job_logs[job_id].append(line)
             log_path = os.path.join(self._job_logs_dir, f"{job_id}.log")
             try:
-                with open(log_path, "a") as f:
+                with open(log_path, "a", encoding="utf-8") as f:
                     f.write(line + "\n")
             except OSError as e:
                 logger.debug(f"Could not append to job log {log_path}: {e}")
@@ -786,7 +786,7 @@ class JobManager:
             log_path = os.path.join(self._job_logs_dir, f"{job_id}.log")
             if os.path.isfile(log_path):
                 try:
-                    with open(log_path, "r") as f:
+                    with open(log_path, "r", encoding="utf-8") as f:
                         logs = [line.rstrip("\n") for line in f if line]
                     if last_n:
                         return logs[-last_n:]
@@ -829,7 +829,7 @@ class JobManager:
             log_path = os.path.join(self._job_logs_dir, f"{job_id}.log")
             if os.path.isfile(log_path):
                 try:
-                    with open(log_path, "r") as f:
+                    with open(log_path, "r", encoding="utf-8") as f:
                         all_lines = [line.rstrip("\n") for line in f if line]
                     total = len(all_lines)
                     end = offset + limit if limit is not None else total
@@ -892,7 +892,7 @@ class JobManager:
         }
         path = self._file_results_path(job_id)
         try:
-            with open(path, "a") as f:
+            with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(record, separators=(",", ":")) + "\n")
         except OSError as e:
             logger.debug(f"Could not append file result to {path}: {e}")
@@ -919,7 +919,7 @@ class JobManager:
         results: List[dict] = []
         search_lower = search.lower() if search else ""
         try:
-            with open(path, "r") as f:
+            with open(path, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if not line:

--- a/plex_generate_previews/web/routes/api_bif.py
+++ b/plex_generate_previews/web/routes/api_bif.py
@@ -12,6 +12,7 @@ from loguru import logger
 from ..auth import api_token_required
 from . import api
 from ._helpers import limiter
+from pathlib import Path
 
 _MAX_SEARCH_RESULTS = 15
 
@@ -260,7 +261,7 @@ def _item_to_result(
 @api.route("/bif/search")
 @api_token_required
 @limiter.limit("10 per minute")
-def bif_search():
+def bif_search() -> tuple:
     """Search Plex for media items and return BIF availability.
 
     Supports plain title queries (``Inception``) as well as season/episode
@@ -375,7 +376,7 @@ def bif_search():
 
 @api.route("/bif/info")
 @api_token_required
-def bif_info():
+def bif_info() -> tuple:
     """Return detailed BIF metadata for troubleshooting.
 
     Query params:
@@ -422,7 +423,7 @@ def bif_info():
 
 @api.route("/bif/frame")
 @api_token_required
-def bif_frame():
+def bif_frame() -> tuple:
     """Serve a single JPEG frame extracted from a BIF file.
 
     Query params:

--- a/plex_generate_previews/web/routes/api_plex.py
+++ b/plex_generate_previews/web/routes/api_plex.py
@@ -18,7 +18,7 @@ PLEX_HEADERS = {
 
 @api.route("/plex/auth/pin", methods=["POST"])
 @setup_or_auth_required
-def create_plex_pin():
+def create_plex_pin() -> tuple:
     """Create a new PIN for Plex OAuth authentication."""
     import requests
 
@@ -58,7 +58,7 @@ def create_plex_pin():
 
 @api.route("/plex/auth/pin/<int:pin_id>")
 @setup_or_auth_required
-def check_plex_pin(pin_id: int):
+def check_plex_pin(pin_id: int) -> tuple:
     """Check if a PIN has been authenticated."""
     import requests
 
@@ -99,7 +99,7 @@ def check_plex_pin(pin_id: int):
 
 @api.route("/plex/servers")
 @setup_or_auth_required
-def get_plex_servers():
+def get_plex_servers() -> tuple:
     """Get user's Plex servers."""
     import requests
 
@@ -158,7 +158,7 @@ def get_plex_servers():
 
 @api.route("/plex/libraries")
 @setup_or_auth_required
-def get_plex_libraries():
+def get_plex_libraries() -> tuple:
     """Get libraries from a Plex server."""
     import requests
 
@@ -221,7 +221,7 @@ def get_plex_libraries():
 
 @api.route("/plex/test", methods=["POST"])
 @setup_or_auth_required
-def test_plex_connection():
+def test_plex_connection() -> tuple:
     """Test connection to a Plex server."""
     import requests
 

--- a/plex_generate_previews/web/routes/api_schedules.py
+++ b/plex_generate_previews/web/routes/api_schedules.py
@@ -20,7 +20,7 @@ def get_schedules():
 
 @api.route("/schedules/<schedule_id>")
 @api_token_required
-def get_schedule(schedule_id):
+def get_schedule(schedule_id: int) -> tuple:
     """Get a specific schedule."""
     schedule_manager = get_schedule_manager()
     schedule = schedule_manager.get_schedule(schedule_id)
@@ -31,7 +31,7 @@ def get_schedule(schedule_id):
 
 @api.route("/schedules", methods=["POST"])
 @api_token_required
-def create_schedule():
+def create_schedule() -> tuple:
     """Create a new schedule."""
     data = request.get_json() or {}
 
@@ -66,7 +66,7 @@ def create_schedule():
 
 @api.route("/schedules/<schedule_id>", methods=["PUT"])
 @api_token_required
-def update_schedule(schedule_id):
+def update_schedule(schedule_id: int) -> tuple:
     """Update a schedule."""
     data = request.get_json() or {}
 
@@ -90,7 +90,7 @@ def update_schedule(schedule_id):
 
 @api.route("/schedules/<schedule_id>", methods=["DELETE"])
 @api_token_required
-def delete_schedule(schedule_id):
+def delete_schedule(schedule_id: int) -> tuple:
     """Delete a schedule."""
     schedule_manager = get_schedule_manager()
     if schedule_manager.delete_schedule(schedule_id):
@@ -100,7 +100,7 @@ def delete_schedule(schedule_id):
 
 @api.route("/schedules/<schedule_id>/enable", methods=["POST"])
 @api_token_required
-def enable_schedule(schedule_id):
+def enable_schedule(schedule_id: int) -> tuple:
     """Enable a schedule."""
     schedule_manager = get_schedule_manager()
     schedule = schedule_manager.enable_schedule(schedule_id)
@@ -111,7 +111,7 @@ def enable_schedule(schedule_id):
 
 @api.route("/schedules/<schedule_id>/disable", methods=["POST"])
 @api_token_required
-def disable_schedule(schedule_id):
+def disable_schedule(schedule_id: int) -> tuple:
     """Disable a schedule."""
     schedule_manager = get_schedule_manager()
     schedule = schedule_manager.disable_schedule(schedule_id)
@@ -122,7 +122,7 @@ def disable_schedule(schedule_id):
 
 @api.route("/schedules/<schedule_id>/run", methods=["POST"])
 @api_token_required
-def run_schedule_now(schedule_id):
+def run_schedule_now(schedule_id: int) -> tuple:
     """Run a schedule immediately."""
     schedule_manager = get_schedule_manager()
     if schedule_manager.run_now(schedule_id):

--- a/plex_generate_previews/web/routes/api_system.py
+++ b/plex_generate_previews/web/routes/api_system.py
@@ -23,7 +23,7 @@ from ._helpers import (
 
 @api.route("/system/rescan-gpus", methods=["POST"])
 @setup_or_auth_required
-def rescan_gpus():
+def rescan_gpus() -> tuple:
     """Force GPU re-detection and return updated list."""
     try:
         with _gpu_cache_lock:
@@ -39,7 +39,7 @@ def rescan_gpus():
 
 @api.route("/system/status")
 @setup_or_auth_required
-def get_system_status():
+def get_system_status() -> tuple:
     """Get system status including GPU info.
 
     GPU detection runs lazily on first access and is cached for the lifetime
@@ -68,7 +68,7 @@ def get_system_status():
 
 @api.route("/system/config")
 @api_token_required
-def get_config():
+def get_config() -> tuple:
     """Get current configuration."""
     try:
         from ...config import get_cached_config
@@ -534,7 +534,7 @@ def _fetch_libraries_via_http(
 
 @api.route("/libraries")
 @api_token_required
-def get_libraries():
+def get_libraries() -> tuple:
     """Get available Plex libraries.
 
     Accepts optional query params 'url' and 'token' to override saved

--- a/plex_generate_previews/web/routes/socketio_handlers.py
+++ b/plex_generate_previews/web/routes/socketio_handlers.py
@@ -23,7 +23,7 @@ def _leave_all_level_rooms() -> None:
         leave_room(lvl)
 
 
-def register_socketio_handlers(socketio):
+def register_socketio_handlers(socketio) -> None:
     """Register SocketIO event handlers."""
 
     # ----- /jobs namespace -----

--- a/plex_generate_previews/web/scheduler.py
+++ b/plex_generate_previews/web/scheduler.py
@@ -105,7 +105,7 @@ class ScheduleManager:
         """Load schedule metadata from persistent storage."""
         if os.path.exists(self.schedules_file):
             try:
-                with open(self.schedules_file, "r") as f:
+                with open(self.schedules_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     self._schedules = data.get("schedules", {})
                 logger.info(f"Loaded {len(self._schedules)} schedule configurations")

--- a/plex_generate_previews/web/settings_manager.py
+++ b/plex_generate_previews/web/settings_manager.py
@@ -89,7 +89,7 @@ class SettingsManager:
         """Load settings from file."""
         if self.settings_file.exists():
             try:
-                with open(self.settings_file, "r") as f:
+                with open(self.settings_file, "r", encoding="utf-8") as f:
                     self._settings = json.load(f)
                 logger.debug(f"Loaded settings from {self.settings_file}")
             except Exception as e:
@@ -119,7 +119,7 @@ class SettingsManager:
         """Load setup wizard state from file."""
         if self.setup_state_file.exists():
             try:
-                with open(self.setup_state_file, "r") as f:
+                with open(self.setup_state_file, "r", encoding="utf-8") as f:
                     self._setup_state = json.load(f)
                 logger.debug(f"Loaded setup state from {self.setup_state_file}")
             except Exception as e:

--- a/plex_generate_previews/web/webhooks.py
+++ b/plex_generate_previews/web/webhooks.py
@@ -51,7 +51,7 @@ def _load_history_from_disk() -> None:
     if not path.exists():
         return
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             entries = json.load(f)
         if isinstance(entries, list):
             with _history_lock:
@@ -435,7 +435,7 @@ def _execute_webhook_job(debounce_key: str) -> None:
 
 @webhooks_bp.route("/radarr", methods=["POST"])
 @_authenticate_webhook
-def radarr_webhook():
+def radarr_webhook() -> tuple:
     """Receive Radarr webhook payloads."""
     data = request.get_json(force=True, silent=True)
     if not data:
@@ -601,7 +601,7 @@ def sportarr_webhook():
 
 @webhooks_bp.route("/custom", methods=["POST"])
 @_authenticate_webhook
-def custom_webhook():
+def custom_webhook() -> tuple:
     """Receive custom webhook payloads (e.g. from Tdarr, scripts, or other tools).
 
     Expected JSON body:

--- a/plex_generate_previews/worker.py
+++ b/plex_generate_previews/worker.py
@@ -27,19 +27,19 @@ _job_thread_ids: set = set()
 _job_thread_ids_lock = threading.Lock()
 
 
-def register_job_thread():
+def register_job_thread() -> None:
     """Register the current thread as belonging to the active job."""
     with _job_thread_ids_lock:
         _job_thread_ids.add(threading.current_thread().ident)
 
 
-def clear_job_threads():
+def clear_job_threads() -> None:
     """Clear all registered job thread IDs (call when job finishes)."""
     with _job_thread_ids_lock:
         _job_thread_ids.clear()
 
 
-def unregister_job_thread():
+def unregister_job_thread() -> None:
     """Remove only the current thread from job tracking.
 
     Unlike ``clear_job_threads`` which wipes the entire set, this removes
@@ -1024,7 +1024,7 @@ class WorkerPool:
         plex,
         worker_progress,
         main_progress,
-        main_task_id=None,
+        main_task_id: int=None,
         title_max_width: int = 20,
         library_name: str = "",
     ) -> dict:


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be made a bit more robust and readable. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Explicit encoding for file operations
- `auth.py`: added `encoding="utf-8"` to 1 `open()` call(s)
- `jobs.py`: added `encoding="utf-8"` to 6 `open()` call(s)
- `scheduler.py`: added `encoding="utf-8"` to 1 `open()` call(s)
- `settings_manager.py`: added `encoding="utf-8"` to 2 `open()` call(s)
- `webhooks.py`: added `encoding="utf-8"` to 1 `open()` call(s)

I added explicit encoding here because Python's default behavior depends on the operating system. This change ensures the code handles text consistently whether it is running on Windows, Linux, or macOS, preventing potential UnicodeDecodeErrors.

### Type hint additions
- `api_bif.py`: added type hints to 3 function(s)
- `api_plex.py`: added type hints to 5 function(s)
- `api_schedules.py`: added type hints to 7 function(s)
- `api_system.py`: added type hints to 4 function(s)
- `app.py`: added type hints to 2 function(s)
- `config.py`: added type hints to 3 function(s)
- `logging_config.py`: added type hints to 2 function(s)
- `processing.py`: added type hints to 1 function(s)
- `socketio_handlers.py`: added type hints to 1 function(s)
- `webhooks.py`: added type hints to 2 function(s)
- `worker.py`: added type hints to 4 function(s)

I have added basic type annotations based on variable names and default values. This should make the code easier to work with in modern IDEs without changing any of the actual logic.

### Examples of changes
**Example change in `api_bif.py`:**
```diff
+from pathlib import Path
-def bif_search():
+def bif_search() -> tuple:
-def bif_info():
+def bif_info() -> tuple:
-def bif_frame():
+def bif_frame() -> tuple:
```

**Example change in `api_plex.py`:**
```diff
-def create_plex_pin():
+def create_plex_pin() -> tuple:
-def check_plex_pin(pin_id: int):
+def check_plex_pin(pin_id: int) -> tuple:
-def get_plex_servers():
+def get_plex_servers() -> tuple:
-def get_plex_libraries():
+def get_plex_libraries() -> tuple:
-def test_plex_connection():
+def test_plex_connection() -> tuple:
```

---

### Safety and verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- Files using dynamic patterns like `eval()` or `globals()` were automatically skipped.
- I did not modify any `__init__.py` files.

Let me know if you would like me to change anything here.